### PR TITLE
fix(eso): update ESO API version from v1beta1 to v1

### DIFF
--- a/charts/infrastructure/external-dns/templates/cloudflare-token.yaml
+++ b/charts/infrastructure/external-dns/templates/cloudflare-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-api-token

--- a/charts/infrastructure/external-secrets/templates/cluster-secret-store.yaml
+++ b/charts/infrastructure/external-secrets/templates/cluster-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: onepassword

--- a/charts/infrastructure/kube-prometheus-stack/templates/grafana-cloud-credentials.yaml
+++ b/charts/infrastructure/kube-prometheus-stack/templates/grafana-cloud-credentials.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana-cloud-credentials


### PR DESCRIPTION
ClusterSecretStore and ExternalSecret were promoted to v1 in ESO 0.9+.
The installed version no longer serves v1beta1, causing resource mapping failures during ArgoCD sync.

```
one or more objects failed to apply, reason: resource mapping not found for name: "onepassword" namespace: "external-secrets" from "/dev/shm/1920867536": no matches for kind "ClusterSecretStore" in version "external-secrets.io/v1beta1"
ensure CRDs are installed first. Retrying attempt #5 at 3:11AM.
```

<img width="1303" height="803" alt="image" src="https://github.com/user-attachments/assets/e16233c2-c2dc-4d9f-a7eb-0469ef962d61" />
